### PR TITLE
Fix load order

### DIFF
--- a/src/plugins/felixhayashi/hotzone/startup.hotzone.js
+++ b/src/plugins/felixhayashi/hotzone/startup.hotzone.js
@@ -17,7 +17,7 @@ module-type: startup
 // Export name and synchronous status
 exports.name = "hotzone";
 exports.platforms = ["browser"];
-exports.after = ["story"];
+exports.after = ["render"];
 exports.synchronous = true;
 
 exports.startup = function() {


### PR DESCRIPTION
It seems that on the current TiddlyWiki master (at least), `storyRiverElement` is `undefined`, because `hotzone` could be loaded before the page is rendered.

This pull request remedies that.